### PR TITLE
Fixed the github input tags and Releasing App with actual ReleaseNotes

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -53,10 +53,10 @@ jobs:
           
       - name: set semver for input tags
         id: semver_input
-        if: ${{ steps.check-tag.outputs.is_tag_build == 'true' }} && contains(github.event.inputs.tags, '-pre+build.')
-        run: | 
+        if: contains(github.event.inputs.tags, '-pre+build.')
+        run: |
           regex=".*(v(([0-9]+\.[0-9]+\.[0-9]+)-pre\+build.[0-9]+))"
-          if [[ ${{ github.event.inputs.tags }} =~ $regex ]]; then
+          if ${{ steps.check-tag.outputs.is_tag_build == 'true' }} && [[ ${{ github.event.inputs.tags }} =~ $regex ]]; then
             echo "::set-output name=tag::${BASH_REMATCH[1]}"
             echo "::set-output name=semver::${BASH_REMATCH[2]}"
             echo "::set-output name=version::${BASH_REMATCH[3]}"

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -18,6 +18,9 @@ on:
         required: true
         default: 'Bluedot-React-Native-Plugin release'
 
+env:
+ RN_PATH: "ReleaseNotes.md"
+
 jobs:
   prepare-pre-release:
     runs-on: ubuntu-latest
@@ -33,7 +36,7 @@ jobs:
         id: check-tag
         if: |
           contains(github.ref, '-pre+build.') ||
-          contains(github.event.inputs.tag, '-pre+build.')
+          contains(github.event.inputs.tags, '-pre+build.')
         run: |
           echo "::set-output name=is_tag_build::true"
 
@@ -256,8 +259,8 @@ jobs:
   deploy-to-appcenter:
     runs-on: ubuntu-latest
 
-    needs: [build-android-app, build-ios-app]
-
+    needs: [prepare-pre-release, build-android-app, build-ios-app]
+    
     steps:
       # Checks-out your repository to get release notes
       - name: Checkout code
@@ -266,14 +269,25 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v2
 
-      - name: Read file contents
+      - name: Extract files
+        uses: a7ul/tar-action@v1.1.0
+        id: extract
+        with:
+          command: x
+          cwd: ./
+          files: ${{ needs.prepare-pre-release.outputs.file_name }}
+
+      - name: Read RN
         id: read_file
         uses: andstor/file-reader-action@v1
         with:
-          path: "ReleaseNotes.md"
+         path: ${{ env.RN_PATH }}
+        if: ${{ needs.prepare-pre-release.outputs.is_tag_build }}
+        env:
+         RN_PATH: "./package/ReleaseNotes.md"
 
       - name: File contents
-        run: echo "${{ steps.read_file.outputs.contents }}"
+        run: echo " ${{ steps.read_file.outputs.contents }}"| echo "${{ needs.prepare-pre-release.outputs.is_tag_build }}" | echo "${{ needs.prepare-pre-release.outputs.file_name }}"
 
       - name: upload Android app to App Center
         uses: wzieba/AppCenter-Github-Action@v1

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -7,14 +7,13 @@ on:
   push:
     branches:
       - master
+      - release/*
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+-pre\+build\.[0-9]+'
-  pull_request:
-    branches:
-      - master
+
   workflow_dispatch:
     inputs:
-      tag:
+      tags:
         description: 'Build an app with a specific wrapper version'
         required: true
         default: 'Bluedot-React-Native-Plugin release'
@@ -49,7 +48,7 @@ jobs:
             echo "::set-output name=tag::${BASH_REMATCH[1]}"
             echo "::set-output name=semver::${BASH_REMATCH[2]}"
             echo "::set-output name=version::${BASH_REMATCH[3]}"
-          elif [[ ${{ github.event.inputs.tag }} =~ $regex ]]; then
+          elif [[ ${{ github.event.inputs.tags }} =~ $regex ]]; then
             echo "::set-output name=tag::${BASH_REMATCH[1]}"
             echo "::set-output name=semver::${BASH_REMATCH[2]}"
             echo "::set-output name=version::${BASH_REMATCH[3]}"
@@ -119,7 +118,7 @@ jobs:
           name: pre_release_wrapper
 
       # install pre-release version of RN wrapper when this is a downstream build
-      - name: isntall pre-release wrapper
+      - name: install pre-release wrapper
         if: ${{ needs.prepare-pre-release.outputs.is_tag_build == 'true' }}
         run: |
           npm install ${{ needs.prepare-pre-release.outputs.file_name }}
@@ -261,10 +260,20 @@ jobs:
 
     steps:
       # Checks-out your repository to get release notes
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
       - name: Download artifact
         uses: actions/download-artifact@v2
+
+      - name: Read file contents
+        id: read_file
+        uses: andstor/file-reader-action@v1
+        with:
+          path: "ReleaseNotes.md"
+
+      - name: File contents
+        run: echo "${{ steps.read_file.outputs.contents }}"
 
       - name: upload Android app to App Center
         uses: wzieba/AppCenter-Github-Action@v1
@@ -274,7 +283,7 @@ jobs:
           group: Collaborators
           file: Android/app-release.apk
           notifyTesters: true
-          releaseNotes: ReleaseNotes.md
+          releaseNotes: ${{steps.read_file.outputs.contents}}
           debug: true
 
       - name: upload iOS app to App Center
@@ -285,4 +294,4 @@ jobs:
           group: Collaborators
           file: iOS/RNPointSDKMinimalIntegration.ipa
           notifyTesters: true
-          releaseNotes: ReleaseNotes.md
+          releaseNotes: ${{steps.read_file.outputs.contents}}

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -40,8 +40,6 @@ jobs:
         run: |
           echo "::set-output name=is_tag_build::true"
 
-      
-
       - name: set semver for downstream builds
         if: ${{ steps.check-tag.outputs.is_tag_build == 'true' }}
         id: semver
@@ -51,12 +49,19 @@ jobs:
             echo "::set-output name=tag::${BASH_REMATCH[1]}"
             echo "::set-output name=semver::${BASH_REMATCH[2]}"
             echo "::set-output name=version::${BASH_REMATCH[3]}"
-          elif [[ ${{ github.event.inputs.tags }} =~ $regex ]]; then
+          fi
+          
+      - name: set semver for input tags
+        id: semver_input
+        if: ${{ steps.check-tag.outputs.is_tag_build == 'true' }} && contains(github.event.inputs.tags, '-pre+build.')
+        run: | 
+          regex=".*(v(([0-9]+\.[0-9]+\.[0-9]+)-pre\+build.[0-9]+))"
+          if [[ ${{ github.event.inputs.tags }} =~ $regex ]]; then
             echo "::set-output name=tag::${BASH_REMATCH[1]}"
             echo "::set-output name=semver::${BASH_REMATCH[2]}"
             echo "::set-output name=version::${BASH_REMATCH[3]}"
           fi
-      
+          
       - name: download pre-release wrapper
         if: ${{ steps.check-tag.outputs.is_tag_build == 'true' }}
         uses: i3h/download-release-asset@v1


### PR DESCRIPTION
The below release shows the ReleaseNotes picked from Min Integration App
https://appcenter.ms/orgs/bluedot/apps/BDReactNativeIntegration/distribute/releases/52

And for a downstream build Release notes were picked from Bluedot react pre-built Wrapper:
https://appcenter.ms/orgs/bluedot/apps/BDReactNativeIntegration-1/distribute/releases/75