### PR TITLE
fixed Pre-release wrapper extract and RN Path for tag builds

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -303,12 +303,12 @@ jobs:
             echo "$(ls -al ./pre_release_wrapper/)" | echo "$(tar -xvzf ./pre_release_wrapper/${{ needs.prepare-pre-release.outputs.file_name }})"
 
 
-      - name: Set RN Path
+      - name: Set ReleaseNote path for tag build
         if: ${{ needs.prepare-pre-release.outputs.is_tag_build }}
         run: |
           echo "RN_PATH="./package/ReleaseNotes.md"" >> $GITHUB_ENV
 
-      - name: Read RN
+      - name: Read Release Notes
         id: read_file
         uses: andstor/file-reader-action@v1
         with:

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -297,26 +297,25 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v2
 
-      - name: Extract files
+      - name: List names of Prerelease artifact
         if: ${{ needs.prepare-pre-release.outputs.is_tag_build }}
-        uses: a7ul/tar-action@v1.1.0
-        id: extract
-        with:
-          command: x
-          cwd: ./
-          files: ${{ needs.prepare-pre-release.outputs.file_name }}
+        run: |
+            echo "$(ls -al ./pre_release_wrapper/)" | echo "$(tar -xvzf ./pre_release_wrapper/${{ needs.prepare-pre-release.outputs.file_name }})"
+
+
+      - name: Set RN Path
+        if: ${{ needs.prepare-pre-release.outputs.is_tag_build }}
+        run: |
+          echo "RN_PATH="./package/ReleaseNotes.md"" >> $GITHUB_ENV
 
       - name: Read RN
         id: read_file
         uses: andstor/file-reader-action@v1
         with:
          path: ${{ env.RN_PATH }}
-        if: ${{ needs.prepare-pre-release.outputs.is_tag_build }}
-        env:
-         RN_PATH: "./package/ReleaseNotes.md"
 
       - name: File contents
-        run: echo " ${{ steps.read_file.outputs.contents }}"| echo "${{ needs.prepare-pre-release.outputs.is_tag_build }}" | echo "${{ needs.prepare-pre-release.outputs.file_name }}"
+        run: echo " ${{ steps.read_file.outputs.contents }}"
 
       - name: upload Android app to App Center
         uses: wzieba/AppCenter-Github-Action@v1


### PR DESCRIPTION
Fixed a few things:
1. Pre-release wrapper path
2. Cmd to extract Release Notes for tag builds
3. Setting the correct path for Release Notes for tag builds

Here are the last 2 successful deployments with and without tag builds:
https://github.com/Bluedot-Innovation/Bluedot-React-Native-Minimal-Integration/actions/runs/2051787527
https://appcenter.ms/orgs/bluedot/apps/BDReactNativeIntegration/distribute/releases/80

https://github.com/Bluedot-Innovation/Bluedot-React-Native-Minimal-Integration/actions/runs/2051782307
https://appcenter.ms/orgs/bluedot/apps/BDReactNativeIntegration/distribute/releases/81

