### PR TITLE
Clean extra code used to load android sdk from maven internal release.

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 # Single source of truth for feature flags.
 # This file is read by both react-native-config (JS) and the dotenv.gradle script (Android build).
-# Set FIREBASE_ENABLED=true only when a valid google-services.json / GoogleService-Info.plist is present.
-FIREBASE_ENABLED=true
+# Set PUSH_ENABLED=true only when a valid google-services.json
+PUSH_ENABLED=true

--- a/App.js
+++ b/App.js
@@ -12,8 +12,10 @@ import Main from "./components/Main";
 import GeoTriggering from "./components/GeoTriggering";
 import Tempo from "./components/Tempo";
 
-// Forward background / quit-state FCM messages to the Bluedot Push SDK.
-// if (FIREBASE_ENABLED) {
+// If you implement Firebase on the React Native layer, forward background/quit-state FCM messages to the Bluedot Push SDK.
+// Call this once at the module level (outside any component):
+//
+// if (PUSH_ENABLED) {
 //   messaging().setBackgroundMessageHandler(async remoteMessage => {
 //     PushNotifications.onMessageReceived(remoteMessage);
 //   });
@@ -25,12 +27,12 @@ export default function App() {
     requestAllPermissions();
 
     // Forward FCM token updates and foreground messages to the Bluedot Push SDK.
-    // Skipped when FIREBASE_ENABLED is false (no google-services config present).
-    // const unsubscribeToken = FIREBASE_ENABLED
+    // Skipped when PUSH_ENABLED is false (no google-services config present).
+    // const unsubscribeToken = PUSH_ENABLED
     //   ? messaging().onTokenRefresh(token => { PushNotifications.onNewFcmToken(token); })
     //   : () => {};
 
-    // const unsubscribeMessage = FIREBASE_ENABLED
+    // const unsubscribeMessage = PUSH_ENABLED
     //   ? messaging().onMessage(async remoteMessage => { PushNotifications.onMessageReceived(remoteMessage); })
     //   : () => {};
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
 apply from: "../../node_modules/react-native-config/android/dotenv.gradle"
-// Apply the Google Services plugin only when FIREBASE_ENABLED=true in the root .env file.
+// Apply the Google Services plugin only when PUSH_ENABLED=true in the root .env file.
 // This lets the app build without a google-services.json file.
-if (project.env.get("FIREBASE_ENABLED") == "true") {
+if (project.env.get("PUSH_ENABLED") == "true") {
     apply plugin: 'com.google.gms.google-services'
 }
 
@@ -170,17 +170,6 @@ android {
     }
 }
 
-def gitlabPipelineId = project.findProperty('gitlabPipelineId') ?: ''
-def sdkDependency
-def pointSdkDependency
-if (gitlabPipelineId) {
-    sdkDependency      = "au.com.bluedot:pushnotifications:${gitlabPipelineId}"
-    pointSdkDependency = "au.com.bluedot:pointsdk:${gitlabPipelineId}"
-} else {
-    sdkDependency      = 'com.gitlab.bluedotio.android:pushnotifications:18.0.0'
-    pointSdkDependency = 'com.gitlab.bluedotio.android:point_sdk_android:18.0.0'
-}
-
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
@@ -189,10 +178,10 @@ dependencies {
     // DEV - to load a package from plugin subfolder we clone plugin's repo and install it as android dependency - to be removed in production
     implementation project(':bluedot-react-native-pushnotifications') 
 
-    // Optional - only use when you want to use your own implementation of FirebaseMessagingService.
+    // Optional - only use next four declarations when you want to use your own implementation of FirebaseMessagingService.
     // Otherwise the default implementation provided by the bluedot-react-native-pushnotifications package will be used.
-    implementation sdkDependency
-    implementation pointSdkDependency
+    implementation 'com.gitlab.bluedotio.android:point_sdk_push:18.0.0'
+    implementation 'com.gitlab.bluedotio.android:point_sdk_android:18.0.0'
     implementation platform("com.google.firebase:firebase-bom:34.12.0")
     implementation "com.google.firebase:firebase-messaging"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,21 +34,3 @@ buildscript {
     }
 }
 
-allprojects {
-    def gitlabMavenToken = project.findProperty('gitlabMavenToken') ?: ''
-    def gitlabPipelineId = project.findProperty('gitlabPipelineId') ?: ''
-    if (gitlabPipelineId) {
-        repositories {
-            maven {
-                url 'https://gitlab.com/api/v4/projects/14682665/packages/maven'
-                credentials(HttpHeaderCredentials) {
-                    name  'Private-Token'
-                    value gitlabMavenToken
-                }
-                authentication {
-                    header(HttpHeaderAuthentication)
-                }
-            }
-        }
-    }
-}

--- a/config.js
+++ b/config.js
@@ -4,10 +4,10 @@
  * Values are driven by the root .env file and surfaced at runtime via
  * react-native-config — edit .env to change them.
  *
- * FIREBASE_ENABLED — set to true only when you have a valid
+ * PUSH_ENABLED — set to true only when you have a valid
  *   google-services.json (Android) / GoogleService-Info.plist (iOS).
  *   When false, all Firebase / FCM push-notification wiring is skipped.
  */
 import Config from 'react-native-config';
 
-export const FIREBASE_ENABLED = Config.FIREBASE_ENABLED === 'true';
+export const PUSH_ENABLED = Config.PUSH_ENABLED === 'true';

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@react-native/babel-preset": "0.83.0",
         "@react-native/gradle-plugin": "0.83.0",
         "@react-native/metro-config": "0.83.0",
-        "bluedot-react-native": "Bluedot-Innovation/Bluedot-React-Native-Plugin#dev/push",
+        "bluedot-react-native": "Bluedot-Innovation/Bluedot-React-Native-Plugin#ak/18.0.0-cleanup",
         "expo": "55.0.4",
         "expo-application": "~55.0.8",
         "expo-constants": "~55.0.7",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@react-native/babel-preset": "0.83.0",
     "@react-native/gradle-plugin": "0.83.0",
     "@react-native/metro-config": "0.83.0",
-    "bluedot-react-native": "Bluedot-Innovation/Bluedot-React-Native-Plugin#dev/push",
+    "bluedot-react-native": "Bluedot-Innovation/Bluedot-React-Native-Plugin#ak/18.0.0-cleanup",
     "expo": "55.0.4",
     "expo-application": "~55.0.8",
     "expo-constants": "~55.0.7",

--- a/react-native-config.d.ts
+++ b/react-native-config.d.ts
@@ -1,6 +1,6 @@
 declare module 'react-native-config' {
   export interface NativeConfig {
-      FIREBASE_ENABLED?: Boolean;
+      PUSH_ENABLED?: Boolean;
   }
   
   export const Config: NativeConfig

--- a/scripts/install-pushnotifications.js
+++ b/scripts/install-pushnotifications.js
@@ -13,12 +13,13 @@ const path = require('path');
 const os = require('os');
 
 const REPO = 'git@github.com:Bluedot-Innovation/Bluedot-React-Native-Plugin.git';
-const BRANCH = 'dev/push';
+const BRANCH = 'ak/18.0.0-cleanup';
 const SUBDIR = 'bluedot-react-native-pushnotifications';
 const TARGET = path.resolve(__dirname, '..', 'node_modules', SUBDIR);
 
-// Skip if already installed with a valid package.json
-if (fs.existsSync(path.join(TARGET, 'package.json'))) {
+// Skip if already installed with a valid package.json AND versions.gradle is present
+const versionsGradlePath = path.resolve(__dirname, '..', 'node_modules', 'versions.gradle');
+if (fs.existsSync(path.join(TARGET, 'package.json')) && fs.existsSync(versionsGradlePath)) {
   console.log(`✓ ${SUBDIR} already installed, skipping`);
   process.exit(0);
 }
@@ -45,6 +46,18 @@ try {
 
   fs.rmSync(TARGET, { recursive: true, force: true });
   fs.cpSync(path.join(tmpDir, SUBDIR), TARGET, { recursive: true });
+
+  // Copy versions.gradle from repo root — the plugin's build.gradle references it via '../../versions.gradle'
+  // which resolves to node_modules/versions.gradle when installed as an npm package.
+  const versionsGradleSrc = path.join(tmpDir, 'versions.gradle');
+  const versionsGradleDest = path.resolve(__dirname, '..', 'node_modules', 'versions.gradle');
+  if (fs.existsSync(versionsGradleSrc)) {
+    fs.copyFileSync(versionsGradleSrc, versionsGradleDest);
+    console.log(`✓ versions.gradle copied to node_modules/`);
+  } else {
+    console.warn(`⚠ versions.gradle not found in repo root, creating empty placeholder`);
+    fs.writeFileSync(versionsGradleDest, '// versions.gradle placeholder\n');
+  }
 
   console.log(`✓ ${SUBDIR} installed successfully`);
 } catch (err) {


### PR DESCRIPTION
Now we can easily switch between builds with or without push notifications using .env/PUSH_ENABLED flag.